### PR TITLE
Update core API and replay format to use 64*4bits of entropy for RNG seed

### DIFF
--- a/src/Multirole/Core/DLWrapper.cpp
+++ b/src/Multirole/Core/DLWrapper.cpp
@@ -83,7 +83,7 @@ IWrapper::Duel DLWrapper::CreateDuel(const DuelOptions& opts)
 	auto ssdIter = ssdList.insert(ssdList.end(), {opts.scriptSupplier, OCG_LoadScript});
 	OCG_DuelOptions options =
 	{
-		opts.seed,
+		{opts.seed[0U], opts.seed[1U], opts.seed[2U], opts.seed[3U]},
 		opts.flags,
 		opts.team1,
 		opts.team2,

--- a/src/Multirole/Core/HornetWrapper.cpp
+++ b/src/Multirole/Core/HornetWrapper.cpp
@@ -118,7 +118,7 @@ IWrapper::Duel HornetWrapper::CreateDuel(const DuelOptions& opts)
 	auto* wptr = hss->bytes.data();
 	Write<OCG_DuelOptions>(wptr,
 	{
-		opts.seed,
+		{opts.seed[0U], opts.seed[1U], opts.seed[2U], opts.seed[3U]},
 		opts.flags,
 		opts.team1,
 		opts.team2,

--- a/src/Multirole/Core/IWrapper.hpp
+++ b/src/Multirole/Core/IWrapper.hpp
@@ -1,5 +1,6 @@
 #ifndef IWRAPPER_HPP
 #define IWRAPPER_HPP
+#include <array>
 #include <cstdint>
 #include <vector>
 #include <stdexcept>
@@ -40,10 +41,12 @@ public:
 
 	struct DuelOptions
 	{
+		using SeedType = std::array<uint64_t, 4>;
+
 		IDataSupplier& dataSupplier;
 		IScriptSupplier& scriptSupplier;
 		ILogger* optLogger;
-		uint64_t seed[4U];
+		SeedType seed;
 		uint64_t flags;
 		Player team1;
 		Player team2;

--- a/src/Multirole/Core/IWrapper.hpp
+++ b/src/Multirole/Core/IWrapper.hpp
@@ -43,7 +43,7 @@ public:
 		IDataSupplier& dataSupplier;
 		IScriptSupplier& scriptSupplier;
 		ILogger* optLogger;
-		uint32_t seed;
+		uint64_t seed[4U];
 		uint64_t flags;
 		Player team1;
 		Player team2;

--- a/src/Multirole/Room/State/Dueling.cpp
+++ b/src/Multirole/Room/State/Dueling.cpp
@@ -39,7 +39,7 @@ constexpr auto CORE_EXC_REASON = Context::DuelFinishReason
 StateOpt Context::operator()(State::Dueling& s) noexcept
 {
 	using namespace YGOPro;
-	const uint64_t seed[4U] =
+	const auto seed = Core::IWrapper::DuelOptions::SeedType
 	{{
 		rng(),
 		rng(),
@@ -77,7 +77,7 @@ StateOpt Context::operator()(State::Dueling& s) noexcept
 	s.replay = std::make_unique<YGOPro::Replay>
 	(
 		static_cast<uint32_t>(CurrentTime()),
-		seed,
+		static_cast<uint32_t>(seed[0U]), // FIXME: Use the entire value!
 		hostInfo,
 		extraCards
 	);

--- a/src/Multirole/Room/State/Dueling.cpp
+++ b/src/Multirole/Room/State/Dueling.cpp
@@ -77,7 +77,7 @@ StateOpt Context::operator()(State::Dueling& s) noexcept
 	s.replay = std::make_unique<YGOPro::Replay>
 	(
 		static_cast<uint32_t>(CurrentTime()),
-		static_cast<uint32_t>(seed[0U]), // FIXME: Use the entire value!
+		seed,
 		hostInfo,
 		extraCards
 	);

--- a/src/Multirole/Room/State/Dueling.cpp
+++ b/src/Multirole/Room/State/Dueling.cpp
@@ -39,7 +39,13 @@ constexpr auto CORE_EXC_REASON = Context::DuelFinishReason
 StateOpt Context::operator()(State::Dueling& s) noexcept
 {
 	using namespace YGOPro;
-	const auto seed = static_cast<uint32_t>(rng());
+	const uint64_t seed[4U] =
+	{{
+		rng(),
+		rng(),
+		rng(),
+		rng(),
+	}};
 	// Enable extra rules for the duel.
 	// These are controlled simply by adding custom cards
 	// with the rulesets to the game as playable cards, they will

--- a/src/Multirole/YGOPro/Replay.cpp
+++ b/src/Multirole/YGOPro/Replay.cpp
@@ -30,15 +30,16 @@ enum ReplayTypes
 
 enum ReplayFlags
 {
-	REPLAY_COMPRESSED     = 0x1,
-	REPLAY_TAG            = 0x2,
-	REPLAY_DECODED        = 0x4,
-	REPLAY_SINGLE_MODE    = 0x8,
-	REPLAY_LUA64          = 0x10,
-	REPLAY_NEWREPLAY      = 0x20,
-	REPLAY_HAND_TEST      = 0x40,
-	REPLAY_DIRECT_SEED    = 0x80,
-	REPLAY_64BIT_DUELFLAG = 0x100,
+	REPLAY_COMPRESSED      = 0x1,
+	REPLAY_TAG             = 0x2,
+	REPLAY_DECODED         = 0x4,
+	REPLAY_SINGLE_MODE     = 0x8,
+	REPLAY_LUA64           = 0x10,
+	REPLAY_NEWREPLAY       = 0x20,
+	REPLAY_HAND_TEST       = 0x40,
+	REPLAY_DIRECT_SEED     = 0x80,
+	REPLAY_64BIT_DUELFLAG  = 0x100,
+	REPLAY_EXTENDED_HEADER = 0x200,
 };
 
 struct ReplayHeader
@@ -46,10 +47,24 @@ struct ReplayHeader
 	uint32_t type; // See ReplayTypes.
 	uint32_t version; // Unused atm, should be set to YGOPro::ClientVersion.
 	uint32_t flags; // See ReplayFlags.
-	uint32_t seed; // Unix timestamp for YRPX. Core duel seed for YRP.
+	uint32_t timestamp; // Unix timestamp.
 	uint32_t size; // Uncompressed size of whatever is after this header.
 	uint32_t hash; // Unused.
-	uint8_t props[8]; // Used for LZMA compression (check their apis).
+	uint8_t props[8U]; // Used for LZMA compression (check their apis).
+};
+
+constexpr uint32_t YRPX_FLAGS = REPLAY_LUA64 | REPLAY_NEWREPLAY |
+                                REPLAY_64BIT_DUELFLAG;
+constexpr uint32_t YRP_FLAGS = YRPX_FLAGS | REPLAY_DIRECT_SEED |
+                               REPLAY_EXTENDED_HEADER;
+
+struct ExtendedReplayHeader
+{
+	static constexpr uint64_t CURRENT_VERSION = 1U;
+
+	ReplayHeader base;
+	uint64_t version; // Version of this extended header.
+	uint64_t seed[4U]; // New 256bit seed.
 };
 
 // ***** YRPX Binary format *****
@@ -65,7 +80,7 @@ struct ReplayHeader
 // 	data [uint8_t * length]
 
 // ***** YRP Binary format *****
-// ReplayHeader
+// ExtendedReplayHeader
 // team0Count [uint32_t]
 // team0Names [20 char16_t * team0Count]
 // team1Count [uint32_t]
@@ -88,7 +103,7 @@ struct ReplayHeader
 
 Replay::Replay(
 	uint32_t unixTimestamp,
-	uint32_t seed,
+	const std::array<uint64_t, 4U>& seed,
 	const HostInfo& info,
 	const CodeVector& extraCards) noexcept
 	:
@@ -237,15 +252,19 @@ void Replay::Serialize() noexcept
 		// NOLINTNEXTLINE: Message type, Called OLD_REPLAY_FORMAT in common.h.
 		Write<uint8_t>(ptr, 231U);
 		// Replay header for YRP replay format.
-		Write(ptr, ReplayHeader
+		Write(ptr, ExtendedReplayHeader
 		{
-			REPLAY_YRP1,
-			ENCODED_SERVER_VERSION,
-			REPLAY_LUA64 | REPLAY_NEWREPLAY | REPLAY_DIRECT_SEED | REPLAY_64BIT_DUELFLAG,
-			seed,
-			static_cast<uint32_t>(YRPPastHeaderSize()),
-			0U,
-			{}
+			{
+				REPLAY_YRP1,
+				ENCODED_SERVER_VERSION,
+				YRP_FLAGS,
+				0U, // NOTE: Zero'd by extended header. Used to be 32bit seed.
+				static_cast<uint32_t>(YRPPastHeaderSize()),
+				0U,
+				{}
+			},
+			ExtendedReplayHeader::CURRENT_VERSION,
+			{seed[0U], seed[1U], seed[2U], seed[3U]}
 		});
 		// Duelists count and their names.
 		WriteDuelists(ptr);

--- a/src/Multirole/YGOPro/Replay.hpp
+++ b/src/Multirole/YGOPro/Replay.hpp
@@ -25,7 +25,7 @@ public:
 
 	Replay(
 		uint32_t unixTimestamp,
-		uint32_t seed,
+		const std::array<uint64_t, 4U>& seed,
 		const HostInfo& info,
 		const CodeVector& extraCards) noexcept;
 
@@ -41,7 +41,7 @@ public:
 	void Serialize() noexcept;
 private:
 	const uint32_t unixTimestamp;
-	const uint32_t seed;
+	const std::array<uint64_t, 4U> seed;
 	const uint32_t startingLP;
 	const uint32_t startingDrawCount;
 	const uint32_t drawCountPerTurn;

--- a/src/ocgapi_types.h
+++ b/src/ocgapi_types.h
@@ -55,7 +55,7 @@ typedef int (*OCG_ScriptReader)(void* payload, OCG_Duel duel, const char* name);
 typedef void (*OCG_LogHandler)(void* payload, const char* string, int type);
 
 typedef struct OCG_DuelOptions {
-	uint32_t seed;
+	uint64_t seed[4U];
 	uint64_t flags;
 	OCG_Player team1;
 	OCG_Player team2;


### PR DESCRIPTION
Requires:
  * https://github.com/edo9300/ygopro-core/tree/rng
  * https://github.com/edo9300/edopro/tree/replay-rng-update