### PR TITLE
Handle new OCG_DuelOptions parameter: enableUnsafeLibraries

### DIFF
--- a/src/Multirole/Core/DLWrapper.cpp
+++ b/src/Multirole/Core/DLWrapper.cpp
@@ -94,7 +94,8 @@ IWrapper::Duel DLWrapper::CreateDuel(const DuelOptions& opts)
 		&LogHandler,
 		opts.optLogger,
 		&DataReaderDone,
-		&opts.dataSupplier
+		&opts.dataSupplier,
+		0
 	};
 	if(OCG_CreateDuel(&duel, options) != OCG_DUEL_CREATION_SUCCESS)
 	{

--- a/src/Multirole/Core/HornetWrapper.cpp
+++ b/src/Multirole/Core/HornetWrapper.cpp
@@ -169,7 +169,8 @@ IWrapper::Duel HornetWrapper::CreateDuel(const DuelOptions& opts)
 		nullptr, // NOTE: Set on Hornet
 		opts.optLogger,
 		nullptr, // NOTE: Set on Hornet
-		&opts.dataSupplier
+		&opts.dataSupplier,
+		0
 	});
 	NotifyAndWait(Hornet::Action::OCG_CREATE_DUEL);
 	const auto* rptr = hss->bytes.data();

--- a/src/ocgapi_types.h
+++ b/src/ocgapi_types.h
@@ -67,6 +67,7 @@ typedef struct OCG_DuelOptions {
 	void* payload3; /* relayed to errorHandler */
 	OCG_DataReaderDone cardReaderDone;
 	void* payload4; /* relayed to cardReader */
+	uint8_t enableUnsafeLibraries;
 }OCG_DuelOptions;
 
 typedef struct OCG_NewCardInfo {


### PR DESCRIPTION
To be merged once https://github.com/edo9300/ygopro-core/pull/126 is added, this will make the core not load the ``io`` family of functions and block some other potentially dangerous functions