### PR TITLE
Support card races as 64 bit

### DIFF
--- a/src/Multirole/YGOPro/CardDatabase.cpp
+++ b/src/Multirole/YGOPro/CardDatabase.cpp
@@ -179,7 +179,7 @@ const OCG_CardData& CardDatabase::DataFromCode(uint32_t code) const noexcept
 		cd.level = dbLevel & 0x800000FF;
 		cd.lscale = (dbLevel >> 24U) & 0xFF;
 		cd.rscale = (dbLevel >> 16U) & 0xFF;
-		cd.race = sqlite3_column_int(sStmt, 7);
+		cd.race = sqlite3_column_int64(sStmt, 7);
 		cd.attribute = sqlite3_column_int(sStmt, 8);
 	}
 	return cd;

--- a/src/Multirole/YGOPro/CoreUtils.cpp
+++ b/src/Multirole/YGOPro/CoreUtils.cpp
@@ -684,7 +684,6 @@ QueryBuffer SerializeSingleQuery(const QueryOpt& qOpt, bool isPublic) noexcept
 			case QUERY_LEVEL:
 			case QUERY_RANK:
 			case QUERY_ATTRIBUTE:
-			case QUERY_RACE:
 			case QUERY_ATTACK:
 			case QUERY_DEFENSE:
 			case QUERY_BASE_ATTACK:
@@ -696,6 +695,10 @@ QueryBuffer SerializeSingleQuery(const QueryOpt& qOpt, bool isPublic) noexcept
 			case QUERY_COVER:
 			{
 				return sizeof(uint32_t);
+			}
+			case QUERY_RACE:
+			{
+				return sizeof(uint64_t);
 			}
 			case QUERY_REASON_CARD:
 			case QUERY_EQUIP_CARD:

--- a/src/Multirole/YGOPro/CoreUtils.hpp
+++ b/src/Multirole/YGOPro/CoreUtils.hpp
@@ -62,7 +62,7 @@ struct Query
 	uint32_t rank;
 	uint32_t link;
 	uint32_t attribute;
-	uint32_t race;
+	uint64_t race;
 	int32_t attack;
 	int32_t defense;
 	int32_t bAttack;

--- a/src/ocgapi_types.h
+++ b/src/ocgapi_types.h
@@ -35,7 +35,7 @@ typedef struct OCG_CardData {
 	uint32_t type;
 	uint32_t level;
 	uint32_t attribute;
-	uint32_t race;
+	uint64_t race;
 	int32_t attack;
 	int32_t defense;
 	uint32_t lscale;


### PR DESCRIPTION
To be merged once https://github.com/edo9300/ygopro-core/pull/127 is added.
This updates the handling of QUERY_RACE and makes the card race be read as 64 bit from the database