### PR TITLE
Add support for Rush Ritual monsters

### DIFF
--- a/src/Multirole/Room/Context.cpp
+++ b/src/Multirole/Room/Context.cpp
@@ -168,13 +168,19 @@ std::unique_ptr<YGOPro::Deck> Context::LoadDeck(
 	const std::vector<uint32_t>& main,
 	const std::vector<uint32_t>& side) const noexcept
 {
-	auto IsExtraDeckCardType = [](uint32_t type) constexpr -> bool
+	auto IsExtraDeckCardType = [&](uint32_t type, uint32_t code) constexpr -> bool
 	{
 		if((type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ)) != 0U)
 			return true;
 		// NOTE: Link Spells exist.
 		if(((type & TYPE_LINK) != 0U) && ((type & TYPE_MONSTER) != 0U))
 			return true;
+		if((type & TYPE_MONSTER) != 0U && (type & TYPE_RITUAL) != 0U)
+		{
+			const auto cardScope = cdb->ExtraFromCode(code).scope;
+			if((cardScope & SCOPE_RUSH) != 0)
+				return true;
+		}
 		return false;
 	};
 	YGOPro::CodeVector m;
@@ -191,7 +197,7 @@ std::unique_ptr<YGOPro::Deck> Context::LoadDeck(
 		}
 		if((data.type & TYPE_TOKEN) != 0U)
 			continue;
-		if(IsExtraDeckCardType(data.type))
+		if(IsExtraDeckCardType(data.type, data.code))
 			e.push_back(code);
 		else
 			m.push_back(code);

--- a/src/Multirole/Room/Context.cpp
+++ b/src/Multirole/Room/Context.cpp
@@ -222,7 +222,6 @@ std::unique_ptr<YGOPro::Deck> Context::LoadDeck(
 		err);
 }
 
-
 std::unique_ptr<YGOPro::STOCMsg> Context::CheckDeck(const YGOPro::Deck& deck) const noexcept
 {
 	using namespace Error;

--- a/src/Multirole/Room/Context.cpp
+++ b/src/Multirole/Room/Context.cpp
@@ -168,8 +168,8 @@ std::unique_ptr<YGOPro::Deck> Context::LoadDeck(
 	const std::vector<uint32_t>& main,
 	const std::vector<uint32_t>& side) const noexcept
 {
-	const uint64_t  DUEL_EXTRA_DECK_RITUAL = 0x800000000ULL;
-	uint64_t duelFlags = YGOPro::HostInfo::OrDuelFlags(hostInfo.duelFlagsHigh, hostInfo.duelFlagsLow);
+	const uint64_t DUEL_EXTRA_DECK_RITUAL = 0x800000000ULL;
+	const uint64_t duelFlags = YGOPro::HostInfo::OrDuelFlags(hostInfo.duelFlagsHigh, hostInfo.duelFlagsLow);
 	
 	auto IsExtraDeckCardType = [&](uint32_t type) constexpr -> bool
 	{

--- a/src/Multirole/Room/Context.cpp
+++ b/src/Multirole/Room/Context.cpp
@@ -168,8 +168,10 @@ std::unique_ptr<YGOPro::Deck> Context::LoadDeck(
 	const std::vector<uint32_t>& main,
 	const std::vector<uint32_t>& side) const noexcept
 {
-	const uint64_t  DUEL_EXTRA_DECK_RITUAL = 0x800000000;
-	auto IsExtraDeckCardType = [this](uint32_t type) constexpr -> bool
+	const uint64_t  DUEL_EXTRA_DECK_RITUAL = 0x800000000ULL;
+	uint64_t duelFlags = YGOPro::HostInfo::OrDuelFlags(hostInfo.duelFlagsHigh, hostInfo.duelFlagsLow);
+	
+	auto IsExtraDeckCardType = [&](uint32_t type) constexpr -> bool
 	{
 		if((type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ)) != 0U)
 			return true;
@@ -177,7 +179,6 @@ std::unique_ptr<YGOPro::Deck> Context::LoadDeck(
 		if(((type & TYPE_LINK) != 0U) && ((type & TYPE_MONSTER) != 0U))
 			return true;
 		// In Rush, Ritual Monsters are placed in the Extra Deck
-		uint64_t duelFlags = YGOPro::HostInfo::OrDuelFlags(hostInfo.duelFlagsHigh, hostInfo.duelFlagsLow);
 		if ((type & TYPE_RITUAL) != 0U && (type & TYPE_MONSTER) != 0U && (duelFlags & DUEL_EXTRA_DECK_RITUAL) != 0U)
 			return true;
 
@@ -220,6 +221,7 @@ std::unique_ptr<YGOPro::Deck> Context::LoadDeck(
 		std::move(s),
 		err);
 }
+
 
 std::unique_ptr<YGOPro::STOCMsg> Context::CheckDeck(const YGOPro::Deck& deck) const noexcept
 {

--- a/src/Multirole/YGOPro/Config.hpp
+++ b/src/Multirole/YGOPro/Config.hpp
@@ -10,8 +10,8 @@ namespace YGOPro
 constexpr YGOPro::ClientVersion SERVER_VERSION =
 {
 	{
-		40, // NOLINT: Client version major
-		1,  // NOLINT: Client version minor
+		41, // NOLINT: Client version major
+		0,  // NOLINT: Client version minor
 	},
 	{
 		10,  // NOLINT: Core version major

--- a/src/Multirole/YGOPro/Config.hpp
+++ b/src/Multirole/YGOPro/Config.hpp
@@ -14,7 +14,7 @@ constexpr YGOPro::ClientVersion SERVER_VERSION =
 		0,  // NOLINT: Client version minor
 	},
 	{
-		10,  // NOLINT: Core version major
+		11,  // NOLINT: Core version major
 		0   // NOLINT: Core version minor
 	}
 };


### PR DESCRIPTION
- Rush Ritual monsters should now be placed in the Extra Deck instead of the Main Deck.