### PR TITLE
Fix compilation with mingw and use that to generate windows binaries

### DIFF
--- a/.github/workflows/x86-windows.yml
+++ b/.github/workflows/x86-windows.yml
@@ -1,41 +1,23 @@
 name: x86-windows
 on: push
-env:
-  VCPKG_TRIPLET: x86-windows-static
 jobs:
   x86-windows:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
-    - name: Install pre-requisites
-      shell: bash
-      run: |
-        choco install --allow-empty-checksums pkgconfiglite
-        pip install meson ninja
-    - name: Install dependencies
-      uses: lukka/run-vcpkg@v7
+    - name: Setup msys2
+      uses: msys2/setup-msys2@v2
       with:
-        vcpkgGitCommitId: 095a29ce59608465032c3747307dd0009b3e089c
-        vcpkgTriplet: ${{ env.VCPKG_TRIPLET }}
-        vcpkgArguments: boost-asio boost-filesystem boost-date-time boost-interprocess boost-json fmt libgit2 openssl sqlite3
-    - name: Fix Boost.Filesystem library location
-      shell: bash
-      run: |
-        VCPKG_LIBRARYDIR=$VCPKG_ROOT/installed/$VCPKG_TRIPLET/lib
-        cp $VCPKG_LIBRARYDIR/boost_filesystem-vc143-mt-x32-1_88.lib $VCPKG_LIBRARYDIR/libboost_filesystem-vc143-mt-s.lib
-    - name: Set x86 windows build tools as default
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-          arch: win32
+        update: true
+        msystem: mingw32
+        install: mingw-w64-i686-toolchain make mingw-w64-i686-libgit2-winhttp mingw-w64-i686-fmt mingw-w64-i686-boost mingw-w64-i686-sqlite3 mingw-w64-i686-openssl pkgconf mingw-w64-i686-meson
     - name: Meson build
-      shell: cmd
+      shell: msys2 {0}
       run: |
-        set PKG_CONFIG_PATH=%VCPKG_ROOT%\installed\%VCPKG_TRIPLET%\lib\pkgconfig
-        set BOOST_ROOT=%VCPKG_ROOT%\installed\%VCPKG_TRIPLET%
-        meson setup build -Dbackend=ninja -Dbuildtype=release -Dstrip=true -Db_lto=true -Db_ndebug=true
-        meson compile -C build -j2
+        LDFLAGS="-static-libstdc++ -static-libgcc -static" meson setup build -Dbuildtype=release -Dstrip=true -Db_lto=true -Db_ndebug=true
+        meson compile -C build -j$(nproc)
     - name: Setup directory with artifacts
       shell: bash
       run: |
@@ -46,7 +28,7 @@ jobs:
         cp etc/config.json $RDIR/
         sed -i "s/libocgcore\\\\\\\.so/ocgcore\\\\\\\.dll/g" $RDIR/config.json
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Multirole
         path: Multirole/

--- a/meson.build
+++ b/meson.build
@@ -5,21 +5,38 @@ project('multirole', 'c', 'cpp',
 	version : '1.1.0'
 )
 
-static_deps = host_machine.system() == 'windows'
+cc = meson.get_compiler('cpp')
 
-atomic_dep  = meson.get_compiler('cpp').find_library('atomic', required : false)
+is_windows = host_machine.system() == 'windows'
+is_not_msvc = cc.get_id() != 'msvc'
+static_deps = is_windows
+is_mingw = is_windows and is_not_msvc
+
+atomic_dep  = cc.find_library('atomic', required : false)
 boost_dep   = dependency('boost', version : '>=1.78', static : static_deps)
-dl_dep      = meson.get_compiler('cpp').find_library('dl', required : false)
-fs_dep      = meson.get_compiler('cpp').find_library('stdc++fs', required : false)
+dl_dep      = cc.find_library('dl', required : false)
+fs_dep      = cc.find_library('stdc++fs', required : false)
 libgit2_dep = dependency('libgit2', static : static_deps)
 openssl_dep = dependency('openssl', static : static_deps)
-rt_dep      = meson.get_compiler('cpp').find_library('rt', required : false)
+rt_dep      = cc.find_library('rt', required : false)
 sqlite3_dep = dependency('sqlite3', static : static_deps)
 tcm_dep     = dependency('libtcmalloc_minimal', required : get_option('use_tcmalloc'), static : static_deps)
 thread_dep  = dependency('threads')
 
+mingw_deps=[]
+if is_mingw
+	mswsock_dep = cc.find_library('mswsock', required: true)
+	rpcrt4p_dep = cc.find_library('rpcrt4', required: true)
+	winhttp_dep = cc.find_library('winhttp', required: true)
+	mingw_deps = [
+		mswsock_dep,
+		rpcrt4p_dep,
+		winhttp_dep
+	]
+endif
+
 # Get fmt dependency and configure so it's header-only
-fmt_dep = dependency('fmt', version : '>=6.0.0')
+fmt_dep = dependency('fmt', version : '>=6.0.0', static : static_deps and not get_option('fmt_ho'))
 if get_option('fmt_ho')
 	fmt_dep = declare_dependency(compile_args : '-DFMT_HEADER_ONLY', dependencies : fmt_dep)
 	fmt_dep = fmt_dep.partial_dependency(compile_args : true, includes : true)
@@ -102,7 +119,7 @@ executable('multirole', multirole_src_files,
 		sqlite3_dep,
 		tcm_dep,
 		thread_dep
-	])
+	] + mingw_deps)
 
 executable('hornet', hornet_src_files,
 	cpp_args: [

--- a/meson.build
+++ b/meson.build
@@ -8,8 +8,9 @@ project('multirole', 'c', 'cpp',
 static_deps = host_machine.system() == 'windows'
 
 atomic_dep  = meson.get_compiler('cpp').find_library('atomic', required : false)
-boost_dep   = dependency('boost', version : '>=1.78', modules : ['filesystem'], static : static_deps)
+boost_dep   = dependency('boost', version : '>=1.78', static : static_deps)
 dl_dep      = meson.get_compiler('cpp').find_library('dl', required : false)
+fs_dep      = meson.get_compiler('cpp').find_library('stdc++fs', required : false)
 libgit2_dep = dependency('libgit2', static : static_deps)
 openssl_dep = dependency('openssl', static : static_deps)
 rt_dep      = meson.get_compiler('cpp').find_library('rt', required : false)
@@ -93,6 +94,7 @@ executable('multirole', multirole_src_files,
 		atomic_dep,
 		boost_dep,
 		dl_dep,
+		fs_dep,
 		fmt_dep,
 		libgit2_dep,
 		openssl_dep,

--- a/src/Multirole/GitRepo.cpp
+++ b/src/Multirole/GitRepo.cpp
@@ -1,6 +1,7 @@
 #include "GitRepo.hpp"
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
+
 #include <boost/json/value.hpp>
 
 #include "I18N.hpp"
@@ -42,7 +43,7 @@ GitRepo::GitRepo(Service::LogHandler& lh, boost::asio::io_context& ioCtx, const 
 			cred->at("username").as_string().data(),
 			cred->at("password").as_string().data());
 	}
-	if(boost::filesystem::exists(path) && !boost::filesystem::is_directory(path))
+	if(exists(path) && !is_directory(path))
 		throw std::runtime_error(I18N::GIT_REPO_PATH_IS_NOT_DIR);
 	if(!CheckIfRepoExists())
 	{

--- a/src/Multirole/GitRepo.hpp
+++ b/src/Multirole/GitRepo.hpp
@@ -33,7 +33,7 @@ private:
 	Service::LogHandler& lh;
 	const std::string token;
 	const std::string remote;
-	const boost::filesystem::path path;
+	const std::filesystem::path path;
 	std::unique_ptr<Credentials> credPtr;
 	git_repository* repo;
 	std::vector<IGitRepoObserver*> observers;
@@ -47,7 +47,7 @@ private:
 	void ResetToFetchHead();
 
 	GitDiff GetFilesDiff() const;
-	std::vector<boost::filesystem::path> GetTrackedFiles() const;
+	std::vector<std::filesystem::path> GetTrackedFiles() const;
 };
 
 } // namespace Ignis::Multirole

--- a/src/Multirole/IGitRepoObserver.hpp
+++ b/src/Multirole/IGitRepoObserver.hpp
@@ -2,12 +2,12 @@
 #define IGITREPOOBSERVER_HPP
 #include <vector>
 
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 namespace Ignis::Multirole
 {
 
-using PathVector = std::vector<boost::filesystem::path>;
+using PathVector = std::vector<std::filesystem::path>;
 
 struct GitDiff
 {
@@ -19,8 +19,8 @@ struct GitDiff
 class IGitRepoObserver
 {
 public:
-	virtual void OnAdd(const boost::filesystem::path& path, const PathVector& fileList) = 0;
-	virtual void OnDiff(const boost::filesystem::path& path, const GitDiff& diff) = 0;
+	virtual void OnAdd(const std::filesystem::path& path, const PathVector& fileList) = 0;
+	virtual void OnDiff(const std::filesystem::path& path, const GitDiff& diff) = 0;
 protected:
 	inline ~IGitRepoObserver() noexcept = default;
 };

--- a/src/Multirole/Service/BanlistProvider.cpp
+++ b/src/Multirole/Service/BanlistProvider.cpp
@@ -26,19 +26,19 @@ YGOPro::BanlistPtr Service::BanlistProvider::GetBanlistByHash(YGOPro::BanlistHas
 	return nullptr;
 }
 
-void Service::BanlistProvider::OnAdd(const boost::filesystem::path& path, const PathVector& fileList)
+void Service::BanlistProvider::OnAdd(const std::filesystem::path& path, const PathVector& fileList)
 {
 	LoadBanlists(path, fileList);
 }
 
-void Service::BanlistProvider::OnDiff(const boost::filesystem::path& path, const GitDiff& diff)
+void Service::BanlistProvider::OnDiff(const std::filesystem::path& path, const GitDiff& diff)
 {
 	LoadBanlists(path, diff.added);
 }
 
 // private
 
-void Service::BanlistProvider::LoadBanlists(const boost::filesystem::path& path, const PathVector& fileList) noexcept
+void Service::BanlistProvider::LoadBanlists(const std::filesystem::path& path, const PathVector& fileList) noexcept
 {
 	YGOPro::BanlistMap tmp;
 	for(const auto& fn : fileList)
@@ -49,7 +49,7 @@ void Service::BanlistProvider::LoadBanlists(const boost::filesystem::path& path,
 		LOG_INFO(I18N::BANLIST_PROVIDER_LOADING_ONE, fullPath.string());
 		try
 		{
-			std::ifstream f(fullPath.native());
+			std::ifstream f(fullPath);
 			YGOPro::ParseForBanlists(f, tmp);
 		}
 		catch(const std::exception& e)

--- a/src/Multirole/Service/BanlistProvider.hpp
+++ b/src/Multirole/Service/BanlistProvider.hpp
@@ -19,15 +19,15 @@ public:
 	YGOPro::BanlistPtr GetBanlistByHash(YGOPro::BanlistHash hash) const noexcept;
 
 	// IGitRepoObserver overrides
-	void OnAdd(const boost::filesystem::path& path, const PathVector& fileList) override;
-	void OnDiff(const boost::filesystem::path& path, const GitDiff& diff) override;
+	void OnAdd(const std::filesystem::path& path, const PathVector& fileList) override;
+	void OnDiff(const std::filesystem::path& path, const GitDiff& diff) override;
 private:
 	Service::LogHandler& lh;
 	const std::regex fnRegex;
 	YGOPro::BanlistMap banlists;
 	mutable std::shared_mutex mBanlists;
 
-	void LoadBanlists(const boost::filesystem::path& path, const PathVector& fileList) noexcept;
+	void LoadBanlists(const std::filesystem::path& path, const PathVector& fileList) noexcept;
 };
 
 } // namespace Ignis::Multirole

--- a/src/Multirole/Service/CoreProvider.hpp
+++ b/src/Multirole/Service/CoreProvider.hpp
@@ -31,32 +31,32 @@ public:
 
 	using CorePtr = std::shared_ptr<Core::IWrapper>;
 
-	CoreProvider(Service::LogHandler& lh, std::string_view fnRegexStr, const boost::filesystem::path& tmpDir, CoreType type, bool loadPerCall);
+	CoreProvider(Service::LogHandler& lh, std::string_view fnRegexStr, const std::filesystem::path& tmpDir, CoreType type, bool loadPerCall);
 	~CoreProvider() noexcept;
 
 	// Will return a core instance based on the options set.
 	CorePtr GetCore() const;
 
 	// IGitRepoObserver overrides
-	void OnAdd(const boost::filesystem::path& path, const PathVector& fileList) override;
-	void OnDiff(const boost::filesystem::path& path, const GitDiff& diff) override;
+	void OnAdd(const std::filesystem::path& path, const PathVector& fileList) override;
+	void OnDiff(const std::filesystem::path& path, const GitDiff& diff) override;
 private:
 	Service::LogHandler& lh;
 	const std::regex fnRegex;
-	const boost::filesystem::path tmpDir;
+	const std::filesystem::path tmpDir;
 	const CoreType type;
 	const bool loadPerCall;
 	const std::chrono::system_clock::rep uniqueId;
 	std::size_t loadCount;
 	bool shouldTest;
-	boost::filesystem::path coreLoc;
+	std::filesystem::path coreLoc;
 	CorePtr core;
-	std::list<boost::filesystem::path> pLocs; // Previous locations for core file.
+	std::list<std::filesystem::path> pLocs; // Previous locations for core file.
 	mutable std::shared_mutex mCore; // used for both corePath and core.
 
 	CorePtr LoadCore() const;
 
-	void OnGitUpdate(const boost::filesystem::path& path, const PathVector& fileList);
+	void OnGitUpdate(const std::filesystem::path& path, const PathVector& fileList);
 };
 
 } // namespace Ignis::Multirole

--- a/src/Multirole/Service/DataProvider.cpp
+++ b/src/Multirole/Service/DataProvider.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<YGOPro::CardDatabase> Service::DataProvider::GetDatabase() const
 	return db;
 }
 
-void Service::DataProvider::OnAdd(const boost::filesystem::path& path, const PathVector& fileList)
+void Service::DataProvider::OnAdd(const std::filesystem::path& path, const PathVector& fileList)
 {
 	// Filter and add to set of dbs
 	for(const auto& fn : fileList)
@@ -40,7 +40,7 @@ void Service::DataProvider::OnAdd(const boost::filesystem::path& path, const Pat
 	ReloadDatabases();
 }
 
-void Service::DataProvider::OnDiff(const boost::filesystem::path& path, const GitDiff& diff)
+void Service::DataProvider::OnDiff(const std::filesystem::path& path, const GitDiff& diff)
 {
 	// Filter and remove from sets of dbs
 	for(const auto& fn : diff.removed)

--- a/src/Multirole/Service/DataProvider.hpp
+++ b/src/Multirole/Service/DataProvider.hpp
@@ -27,12 +27,12 @@ public:
 	std::shared_ptr<YGOPro::CardDatabase> GetDatabase() const noexcept;
 
 	// IGitRepoObserver overrides
-	void OnAdd(const boost::filesystem::path& path, const PathVector& fileList) override;
-	void OnDiff(const boost::filesystem::path& path, const GitDiff& diff) override;
+	void OnAdd(const std::filesystem::path& path, const PathVector& fileList) override;
+	void OnDiff(const std::filesystem::path& path, const GitDiff& diff) override;
 private:
 	Service::LogHandler& lh;
 	const std::regex fnRegex;
-	std::set<boost::filesystem::path> paths;
+	std::set<std::filesystem::path> paths;
 	std::shared_ptr<YGOPro::CardDatabase> db;
 	mutable std::shared_mutex mDb;
 

--- a/src/Multirole/Service/LogHandler.cpp
+++ b/src/Multirole/Service/LogHandler.cpp
@@ -1,6 +1,6 @@
 #include "LogHandler.hpp"
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include "../I18N.hpp"
 #include "LogHandler/ISink.hpp"
@@ -79,7 +79,6 @@ Service::LogHandler::LogHandler(boost::asio::io_context& ioCtx, const boost::jso
 	};
 	if(!logRooms)
 		return;
-	using namespace boost::filesystem;
 	if(!exists(roomLogsDir) && !create_directory(roomLogsDir))
 		throw std::runtime_error(I18N::LOG_HANDLER_COULD_NOT_CREATE_DIR);
 	if(!is_directory(roomLogsDir))
@@ -121,8 +120,8 @@ std::unique_ptr<RoomLogger> Service::LogHandler::MakeRoomLogger(uint32_t roomId)
 
 // RoomLogger
 
-RoomLogger::RoomLogger(const boost::filesystem::path& path) :
-	f(path.native())
+RoomLogger::RoomLogger(const std::filesystem::path& path) :
+	f(path)
 {
 	if(!f.is_open())
 		throw std::runtime_error(I18N::ROOM_LOGGER_FILE_IS_NOT_OPEN);

--- a/src/Multirole/Service/LogHandler.hpp
+++ b/src/Multirole/Service/LogHandler.hpp
@@ -2,13 +2,13 @@
 #define SERVICE_LOGHANDLER_HPP
 #include <array>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <mutex>
 #include <string_view>
 
 #include <boost/asio/io_context.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/json/object.hpp>
 #include <fmt/format.h>
 
@@ -52,7 +52,7 @@ public:
 	}
 private:
 	const bool logRooms;
-	const boost::filesystem::path roomLogsDir;
+	const std::filesystem::path roomLogsDir;
 	std::mutex mStderr;
 	std::mutex mStdout;
 	std::array<
@@ -68,7 +68,7 @@ private:
 class RoomLogger
 {
 public:
-	RoomLogger(const boost::filesystem::path& path);
+	RoomLogger(const std::filesystem::path& path);
 
 	void Log(std::string_view str) noexcept;
 

--- a/src/Multirole/Service/LogHandler/FileSink.cpp
+++ b/src/Multirole/Service/LogHandler/FileSink.cpp
@@ -7,8 +7,8 @@
 namespace Ignis::Multirole::LogHandlerDetail
 {
 
-FileSink::FileSink(const boost::filesystem::path& p) :
-	f(p.native(), std::ios_base::out | std::ios_base::app)
+FileSink::FileSink(const std::filesystem::path& p) :
+	f(p, std::ios_base::out | std::ios_base::app)
 {}
 
 FileSink::~FileSink() noexcept = default;

--- a/src/Multirole/Service/LogHandler/FileSink.hpp
+++ b/src/Multirole/Service/LogHandler/FileSink.hpp
@@ -2,8 +2,8 @@
 #define MULTIROLE_SERVICE_LOGHANDLER_FILESINK_HPP
 #include "ISink.hpp"
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/fstream.hpp>
+#include <filesystem>
+#include <fstream>
 
 namespace Ignis::Multirole::LogHandlerDetail
 {
@@ -11,7 +11,7 @@ namespace Ignis::Multirole::LogHandlerDetail
 class FileSink final : public ISink
 {
 public:
-	FileSink(const boost::filesystem::path& p);
+	FileSink(const std::filesystem::path& p);
 	~FileSink() noexcept;
 	void Log(const Timestamp& ts, const SinkLogProps& props, std::string_view str) noexcept override;
 private:

--- a/src/Multirole/Service/LogHandler/Timestamp.cpp
+++ b/src/Multirole/Service/LogHandler/Timestamp.cpp
@@ -17,7 +17,7 @@ void FmtTimestamp(std::ostream& os, const Timestamp& timestamp) noexcept
 	const auto tt = system_clock::to_time_t(timestamp);
 	const auto* lt = std::localtime(&tt);
 	std::array<char, 32U> tBuf{};
-	const auto sz1 = std::strftime(tBuf.data(), tBuf.size(), "%Y-%m-%d %T", lt);
+	const auto sz1 = std::strftime(tBuf.data(), tBuf.size(), "%Y-%m-%d %H:%M:%S", lt);
 	std::array<char, 4U> msBuf{};
 	const auto ms = static_cast<unsigned>(duration_cast<milliseconds>(timestamp.time_since_epoch()).count() % 1000U);
 	const auto sz2 = std::snprintf(msBuf.data(), msBuf.size(), "%03u", ms);

--- a/src/Multirole/Service/ReplayManager.hpp
+++ b/src/Multirole/Service/ReplayManager.hpp
@@ -2,11 +2,11 @@
 #define SERVICE_REPLAYMANAGER_HPP
 #include "../Service.hpp"
 
+#include <filesystem>
 #include <mutex>
 #include <string>
 #include <string_view>
 
-#include <boost/filesystem/path.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 
 namespace YGOPro
@@ -22,7 +22,7 @@ namespace Ignis::Multirole
 class Service::ReplayManager
 {
 public:
-	ReplayManager(Service::LogHandler& lh, bool save, const boost::filesystem::path& dir);
+	ReplayManager(Service::LogHandler& lh, bool save, const std::filesystem::path& dir);
 
 	void Save(uint64_t id, const YGOPro::Replay& replay) const noexcept;
 
@@ -30,9 +30,9 @@ public:
 private:
 	Service::LogHandler& lh;
 	const bool save;
-	const boost::filesystem::path dir;
-	const boost::filesystem::path lastId;
-	const boost::filesystem::path lastIdLock;
+	const std::filesystem::path dir;
+	const std::filesystem::path lastId;
+	const std::filesystem::path lastIdLock;
 	std::mutex mLastId; // guarantees thread-safety
 	boost::interprocess::file_lock lLastId; // guarantees process-safety
 };

--- a/src/Multirole/Service/ScriptProvider.cpp
+++ b/src/Multirole/Service/ScriptProvider.cpp
@@ -20,12 +20,12 @@ Service::ScriptProvider::ScriptProvider(Service::LogHandler& lh, std::string_vie
 	fnRegex(fnRegexStr.data())
 {}
 
-void Service::ScriptProvider::OnAdd(const boost::filesystem::path& path, const PathVector& fileList)
+void Service::ScriptProvider::OnAdd(const std::filesystem::path& path, const PathVector& fileList)
 {
 	LoadScripts(path, fileList);
 }
 
-void Service::ScriptProvider::OnDiff(const boost::filesystem::path& path, const GitDiff& diff)
+void Service::ScriptProvider::OnDiff(const std::filesystem::path& path, const GitDiff& diff)
 {
 	LoadScripts(path, diff.added);
 }
@@ -40,7 +40,7 @@ Core::IScriptSupplier::ScriptType Service::ScriptProvider::ScriptFromFilePath(st
 
 // private
 
-void Service::ScriptProvider::LoadScripts(const boost::filesystem::path& path, const PathVector& fileList) noexcept
+void Service::ScriptProvider::LoadScripts(const std::filesystem::path& path, const PathVector& fileList) noexcept
 {
 	int total = 0;
 	LOG_INFO(I18N::SCRIPT_PROVIDER_LOADING_FILES, fileList.size());
@@ -51,7 +51,7 @@ void Service::ScriptProvider::LoadScripts(const boost::filesystem::path& path, c
 			continue;
 		const auto fullPath = (path / fn).lexically_normal();
 		// Open file, checking if it exists
-		std::ifstream file(fullPath.native(), std::ifstream::binary);
+		std::ifstream file(fullPath, std::ifstream::binary);
 		if(!file.is_open())
 		{
 			LOG_ERROR(I18N::SCRIPT_PROVIDER_COULD_NOT_OPEN, fullPath.string());

--- a/src/Multirole/Service/ScriptProvider.hpp
+++ b/src/Multirole/Service/ScriptProvider.hpp
@@ -18,8 +18,8 @@ public:
 	ScriptProvider(Service::LogHandler& lh, std::string_view fnRegexStr);
 
 	// IGitRepoObserver overrides
-	void OnAdd(const boost::filesystem::path& path, const PathVector& fileList) override;
-	void OnDiff(const boost::filesystem::path& path, const GitDiff& diff) override;
+	void OnAdd(const std::filesystem::path& path, const PathVector& fileList) override;
+	void OnDiff(const std::filesystem::path& path, const GitDiff& diff) override;
 
 	// Core::IScriptSupplier overrides
 	ScriptType ScriptFromFilePath(std::string_view fp) const noexcept override;
@@ -29,7 +29,7 @@ private:
 	std::unordered_map<std::string, ScriptType> scripts;
 	mutable std::shared_mutex mScripts;
 
-	void LoadScripts(const boost::filesystem::path& path, const PathVector& fileList) noexcept;
+	void LoadScripts(const std::filesystem::path& path, const PathVector& fileList) noexcept;
 };
 
 } // namespace Ignis::Multirole


### PR DESCRIPTION
Fixes compilation using mingw by removing the dependency on boost::filesystem and using std's one directly (boost's implementation is stil somewhat bugged under windows).
The ci build for windows will now use mingw instead of relying on visual studio/vcpkg